### PR TITLE
FTG-13 | Fix blurry sprites 

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -81,3 +81,7 @@ player_run={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194325,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 ]
 }
+
+[rendering]
+
+textures/canvas_textures/default_texture_filter=0


### PR DESCRIPTION
Texture filtering in Godot 4 was moved to project settings.